### PR TITLE
Adjust item links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This app listens on the Item kinesis stream to identify Item updates that *look 
  * id: Item identifier (unique to item)
  * barcode: Item barcode (unique to item)
  * isbn: Item ISBN (for use looking up cover art?)
+ * link: The link of this item's bib on browse.nypl.org
 
  That list of items is periodically uploaded as an atom feed to S3 for consumption by any client interested in showing a feed of checkouts.
 

--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,5 +1,5 @@
 class Checkout
-  attr_accessor :id, :created, :isbn, :barcode, :title, :author, :catalog_url
+  attr_accessor :id, :created, :isbn, :barcode, :title, :author, :catalog_url, :link
 
   def to_s
     "Checkout #{id}: #{title} by #{author} (isbn #{isbn})"
@@ -35,6 +35,7 @@ class Checkout
 
         checkout.title = bib['title']
         checkout.author = bib['author']
+        checkout.link = "https://browse.nypl.org/iii/encore/record/C__Rb#{item['bibIds'].first}"
 
         # Get ISBN out of 020 $a (per https://docs.google.com/spreadsheets/d/1RtDxIpzcCrVqJqUjmMGkn8n2hX3BZVN9QvbB1HRgx1c/edit#gid=0&range=35:35 ):
         checkout.isbn = self.marc_value bib, '020', 'a'

--- a/lib/s3_writer.rb
+++ b/lib/s3_writer.rb
@@ -26,7 +26,7 @@ class S3Writer
           xml.entry {
             xml.id "#{checkout.id}-#{checkout.barcode}"
             xml.title "\"#{checkout.title}\" by #{checkout.author}"
-            xml.link checkout.id
+            xml.link checkout.link
             xml.updated checkout.created
             xml['dcterms'].title checkout.title if checkout.title
             xml['dc'].contributor checkout.author if checkout.author


### PR DESCRIPTION
This PR modifies the link of each item on the feed to link to browse.nypl.org

For example, Pizza will be https://browse.nypl.org/iii/encore/record/C__Rb20514712?lang=eng