### PR TITLE
Add rspec, better empty property checks

### DIFF
--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,8 +1,14 @@
 class Checkout
-  attr_accessor :id, :created, :isbn, :barcode, :title, :author, :catalog_url, :link
+  attr_accessor :id, :created, :isbn, :barcode, :title, :author, :link
 
   def to_s
     "Checkout #{id}: #{title} by #{author} (isbn #{isbn})"
+  end
+
+  # Return true if named property (e.g. :title) is truthy
+  def has?(prop)
+    val = self.send prop
+    ! val.nil? && ! val.empty?
   end
 
   def self.marc_value(record, marc, subfield)

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -46,7 +46,7 @@ class ItemStreamHandler
         decoded = avro_decoder('Item').decode avro_data
         
         # Presence of 'duedate' indicates it's checked-out
-        if ! decoded['status']['duedate'].nil?
+        if decoded && decoded['status'] && ! decoded['status']['duedate'].nil?
           checkout = Checkout.from_item_record decoded
           add_checkout checkout
           

--- a/lib/s3_writer.rb
+++ b/lib/s3_writer.rb
@@ -27,14 +27,14 @@ class S3Writer
           xml.entry {
             xml.id "#{checkout.id}-#{checkout.barcode}"
             title = "\"#{checkout.title}\""
-            title += " by #{checkout.author}" if checkout.author
+            title += " by #{checkout.author}" if checkout.has? :author
             xml.title title
-            xml.link checkout.link
+            xml.link checkout.link if checkout.has? :link
             xml.updated checkout.created
-            xml['dcterms'].title checkout.title if checkout.title
-            xml['dc'].contributor checkout.author if checkout.author
-            xml['dc'].identifier "urn:isbn:#{checkout.isbn}" if checkout.isbn
-            xml['dc'].identifier "urn:barcode:#{checkout.barcode}" if checkout.barcode
+            xml['dcterms'].title checkout.title if checkout.has? :title
+            xml['dc'].contributor checkout.author if checkout.has? :author
+            xml['dc'].identifier "urn:isbn:#{checkout.isbn}" if checkout.has? :isbn
+            xml['dc'].identifier "urn:barcode:#{checkout.barcode}" if checkout.has? :barcode
           }
         end
       }

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Checkout do
+  describe '#from_item_record' do
+    describe 'laptop item' do
+      before(:each) do
+        mock_api_client = instance_double(PlatformApiClient)
+        allow(PlatformApiClient).to receive(:new).and_return(mock_api_client)
+        allow(mock_api_client).to receive(:get).and_return({ "data" => fixture('bib-laptop.json') })
+        load File.join('application.rb')
+      end
+
+      it 'generates laptop checkout' do
+        checkout = Checkout.from_item_record(fixture('item-laptop.json'))
+
+        expect(checkout).to be_a(Checkout)
+        expect(checkout.id).to eq('34132673')
+        expect(checkout.created).to eq('2019-04-10T17:36:22-04:00')
+        expect(checkout.isbn).to be_nil
+        expect(checkout.barcode).to eq('33333406215299')
+        expect(checkout.title).to eq('Laptops.')
+        expect(checkout.author).to eq('')
+        expect(checkout.link).to eq('https://browse.nypl.org/iii/encore/record/C__Rb17990921')
+      end
+    end
+
+    describe 'laptop item' do
+      before(:each) do
+        mock_api_client = instance_double(PlatformApiClient)
+        allow(PlatformApiClient).to receive(:new).and_return(mock_api_client)
+        allow(mock_api_client).to receive(:get).and_return({ "data" => fixture('bib-cee-lo.json') })
+        load File.join('application.rb')
+      end
+
+      it 'generates cee-lo album checkout' do
+        checkout = Checkout.from_item_record(fixture('item-cee-lo.json'))
+
+        expect(checkout).to be_a(Checkout)
+        expect(checkout.id).to eq('25855062')
+        expect(checkout.created).to eq('2019-04-10T20:52:48-04:00')
+        expect(checkout.isbn).to be_nil
+        expect(checkout.barcode).to eq('33333289418770')
+        expect(checkout.title).to eq('The lady killer [sound recording]')
+        expect(checkout.author).to eq('Cee-Lo (Musician)')
+        expect(checkout.link).to eq('https://browse.nypl.org/iii/encore/record/C__Rb18672258')
+      end
+    end
+  end
+end
+

--- a/spec/fixtures/bib-cee-lo.json
+++ b/spec/fixtures/bib-cee-lo.json
@@ -1,0 +1,719 @@
+{
+  "id": "18672258",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2019-03-14T01:47:09-04:00",
+  "createdDate": "2010-11-04T14:38:10-04:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "huy",
+      "name": "115th Street Young Adult"
+    },
+    {
+      "code": "hdy",
+      "name": "125th Street Young Adult"
+    },
+    {
+      "code": "agy",
+      "name": "Aguilar Young Adult"
+    },
+    {
+      "code": "bay",
+      "name": "Baychester Young Adult"
+    },
+    {
+      "code": "cly",
+      "name": "Morningside Heights Young Adult"
+    },
+    {
+      "code": "csy",
+      "name": "Columbus Young Adult"
+    },
+    {
+      "code": "hpa",
+      "name": "Hudson Park Adult"
+    },
+    {
+      "code": "lmy",
+      "name": "New Amsterdam Young Adult"
+    },
+    {
+      "code": "mha",
+      "name": "Mott Haven Adult"
+    },
+    {
+      "code": "mm",
+      "name": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
+      "code": "moy",
+      "name": "Mosholu Young Adult"
+    },
+    {
+      "code": "mry",
+      "name": "Morrisania Young Adult"
+    },
+    {
+      "code": "ndy",
+      "name": "New Dorp Young Adult"
+    },
+    {
+      "code": "oty",
+      "name": "Ottendorfer Young Adult"
+    },
+    {
+      "code": "rsa",
+      "name": "Riverside Adult"
+    },
+    {
+      "code": "svy",
+      "name": "Soundview Young Adult"
+    },
+    {
+      "code": "tgy",
+      "name": "Throg's Neck Young Adult"
+    },
+    {
+      "code": "wfa",
+      "name": "West Farms Adult"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "The lady killer [sound recording]",
+  "author": "Cee-Lo (Musician)",
+  "materialType": {
+    "code": "y",
+    "value": "MUSIC CD"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 2010,
+  "catalogDate": "2011-09-06",
+  "country": {
+    "code": "nyu",
+    "name": "New York (State)"
+  },
+  "normTitle": "lady killer sound recording",
+  "normAuthor": "cee lo musician",
+  "standardNumbers": [
+    "075678906015"
+  ],
+  "controlNumber": "668202922",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "4",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "multi",
+      "display": null
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "20",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2011-09-06",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "y",
+      "display": "MUSIC CD"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "a",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "18672258",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2010-11-04T14:38:10Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-03-14T01:47:09Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "1664",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "nyu",
+      "display": "New York (State)"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-03-11T14:41:55Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Cee-Lo"
+        },
+        {
+          "tag": "c",
+          "content": "(Musician)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Bennett, Lauren."
+        }
+      ]
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "091",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "f",
+          "content": "CD"
+        },
+        {
+          "tag": "a",
+          "content": "HIPHOP"
+        },
+        {
+          "tag": "c",
+          "content": "Cee-Lo-2922"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Rap (Music)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "024",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "075678906015"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "028",
+      "ind1": "0",
+      "ind2": "2",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "2-525601"
+        },
+        {
+          "tag": "b",
+          "content": "Elektra"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)668202922"
+        },
+        {
+          "tag": "z",
+          "content": "(OCoLC)669068516"
+        },
+        {
+          "tag": "z",
+          "content": "(OCoLC)680057339"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "511",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Cee-Lo."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Compact disc."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "\"Parental advisory: explicit content\"--Container."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "505",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "t",
+          "content": "The lady killer theme (intro) --"
+        },
+        {
+          "tag": "t",
+          "content": "Bright lights bigger city --"
+        },
+        {
+          "tag": "t",
+          "content": "F*** you --"
+        },
+        {
+          "tag": "t",
+          "content": "Wildflower --"
+        },
+        {
+          "tag": "t",
+          "content": "Bodies --"
+        },
+        {
+          "tag": "t",
+          "content": "Love gun"
+        },
+        {
+          "tag": "r",
+          "content": "(feat. Lauren Bennett) --"
+        },
+        {
+          "tag": "t",
+          "content": "Satisfied --"
+        },
+        {
+          "tag": "t",
+          "content": "I want you --"
+        },
+        {
+          "tag": "t",
+          "content": "Cry baby --"
+        },
+        {
+          "tag": "t",
+          "content": "Fool for you --"
+        },
+        {
+          "tag": "t",
+          "content": "It's OK --"
+        },
+        {
+          "tag": "t",
+          "content": "Old fashioned --"
+        },
+        {
+          "tag": "t",
+          "content": "No one's gonna love you --"
+        },
+        {
+          "tag": "t",
+          "content": "The lady killer theme (outro)."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "668202922",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "New York :"
+        },
+        {
+          "tag": "b",
+          "content": "NEK/New Elektra,"
+        },
+        {
+          "tag": "c",
+          "content": "p2010."
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "1 sound disc :"
+        },
+        {
+          "tag": "b",
+          "content": "digital ;"
+        },
+        {
+          "tag": "c",
+          "content": "4 3/4 in."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "The lady killer"
+        },
+        {
+          "tag": "h",
+          "content": "[sound recording] /"
+        },
+        {
+          "tag": "c",
+          "content": "Cee-Lo."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "OCoLC",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20110414125717.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "007",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "sd fsngnnmmneu",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "101001s2010    nyuzznn           n eng dcjmIa ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "019",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "669068516"
+        },
+        {
+          "tag": "a",
+          "content": "680057339"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BTCTA"
+        },
+        {
+          "tag": "b",
+          "content": "eng"
+        },
+        {
+          "tag": "c",
+          "content": "BTCTA"
+        },
+        {
+          "tag": "d",
+          "content": "TEF"
+        },
+        {
+          "tag": "d",
+          "content": "TEFMT"
+        },
+        {
+          "tag": "d",
+          "content": "INO"
+        },
+        {
+          "tag": "d",
+          "content": "EHH"
+        },
+        {
+          "tag": "d",
+          "content": "RLS"
+        },
+        {
+          "tag": "d",
+          "content": "VP@"
+        },
+        {
+          "tag": "d",
+          "content": "IUL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "037",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "Midwest Tape"
+        },
+        {
+          "tag": "n",
+          "content": "http://www.midwesttapes.com"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "049",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "MAIN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "050",
+      "ind1": " ",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "M1630.18.C44"
+        },
+        {
+          "tag": "b",
+          "content": "L23 2010"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "908",
+      "ind1": " ",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "M1630.18.C44"
+        },
+        {
+          "tag": "b",
+          "content": "L23 2010"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "082",
+      "ind1": "0",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "782.42164"
+        },
+        {
+          "tag": "2",
+          "content": "22"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Midwest20110906"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "945",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".o14182324"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Midwest101122"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cjm  2200421Ia 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/fixtures/bib-laptop.json
+++ b/spec/fixtures/bib-laptop.json
@@ -1,0 +1,695 @@
+{
+  "id": "17990921",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2019-04-09T20:20:11-04:00",
+  "createdDate": "2009-02-14T02:49:00-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "fta",
+      "name": "53rd Street Adult"
+    },
+    {
+      "code": "fea",
+      "name": "58th Street Adult"
+    },
+    {
+      "code": "ssa",
+      "name": "67th Street Adult"
+    },
+    {
+      "code": "nsa",
+      "name": "96th Street Adult"
+    },
+    {
+      "code": "hua",
+      "name": "115th Street Adult"
+    },
+    {
+      "code": "hda",
+      "name": "125th Street Adult"
+    },
+    {
+      "code": "aga",
+      "name": "Aguilar Adult"
+    },
+    {
+      "code": "ala",
+      "name": "Allerton Adult"
+    },
+    {
+      "code": "baa",
+      "name": "Baychester Adult"
+    },
+    {
+      "code": "bca",
+      "name": "Bronx Library Center Adult"
+    },
+    {
+      "code": "bea",
+      "name": "Belmont Adult"
+    },
+    {
+      "code": "bey",
+      "name": "Belmont Young Adult"
+    },
+    {
+      "code": "bla",
+      "name": "Bloomingdale Adult"
+    },
+    {
+      "code": "bra",
+      "name": "George Bruce Adult"
+    },
+    {
+      "code": "bta",
+      "name": "Battery Park Adult "
+    },
+    {
+      "code": "caa",
+      "name": "Terence Cardinal Cooke-Cathedral Adult"
+    },
+    {
+      "code": "cha",
+      "name": "Chatham Square Adult"
+    },
+    {
+      "code": "cia",
+      "name": "City Island Adult"
+    },
+    {
+      "code": "cla",
+      "name": "Morningside Heights Adult "
+    },
+    {
+      "code": "cpa",
+      "name": "Clason's Point Adult"
+    },
+    {
+      "code": "csa",
+      "name": "Columbus Adult "
+    },
+    {
+      "code": "cta",
+      "name": "Castle Hill Adult"
+    },
+    {
+      "code": "ctj",
+      "name": "Castle Hill Children"
+    },
+    {
+      "code": "dha",
+      "name": "Dongan Hills Adult"
+    },
+    {
+      "code": "dya",
+      "name": "Spuyten Duyvil Adult "
+    },
+    {
+      "code": "eaa",
+      "name": "Eastchester Adult"
+    },
+    {
+      "code": "epa",
+      "name": "Epiphany Adult"
+    },
+    {
+      "code": "ewa",
+      "name": "Edenwald Adult"
+    },
+    {
+      "code": "fwa",
+      "name": "Fort Washington Adult"
+    },
+    {
+      "code": "fxa",
+      "name": "Francis Martin Adult"
+    },
+    {
+      "code": "gca",
+      "name": "Grand Central Adult "
+    },
+    {
+      "code": "gda",
+      "name": "Grand Concourse Adult"
+    },
+    {
+      "code": "gka",
+      "name": "Great Kills Adult"
+    },
+    {
+      "code": "hba",
+      "name": "High Bridge Adult"
+    },
+    {
+      "code": "hfa",
+      "name": "Hamilton Fish Park Adult"
+    },
+    {
+      "code": "hga",
+      "name": "Hamilton Grange Adult"
+    },
+    {
+      "code": "hgy",
+      "name": "Hamilton Grange Young Adult"
+    },
+    {
+      "code": "hka",
+      "name": "Huguenot Park Adult"
+    },
+    {
+      "code": "hla",
+      "name": "Harlem Adult"
+    },
+    {
+      "code": "hpa",
+      "name": "Hudson Park Adult"
+    },
+    {
+      "code": "hpj",
+      "name": "Hudson Park Children"
+    },
+    {
+      "code": "hsa",
+      "name": "Hunt's Point Adult"
+    },
+    {
+      "code": "hta",
+      "name": "Countee Cullen Adult"
+    },
+    {
+      "code": "ina",
+      "name": "Inwood Adult"
+    },
+    {
+      "code": "jma",
+      "name": "Jefferson Market Adult"
+    },
+    {
+      "code": "jpa",
+      "name": "Jerome Park Adult"
+    },
+    {
+      "code": "kba",
+      "name": "Kingsbridge Adult"
+    },
+    {
+      "code": "kpa",
+      "name": "Kips Bay Adult"
+    },
+    {
+      "code": "lba",
+      "name": "Andrew Heiskell Adult"
+    },
+    {
+      "code": "lma",
+      "name": "New Amsterdam Adult"
+    },
+    {
+      "code": "ls",
+      "name": "Library Services Center"
+    },
+    {
+      "code": "mba",
+      "name": "Macomb's Bridge Adult"
+    },
+    {
+      "code": "mea",
+      "name": "Melrose Adult"
+    },
+    {
+      "code": "mha",
+      "name": "Mott Haven Adult"
+    },
+    {
+      "code": "mhar",
+      "name": "Mott Haven Adult Reference"
+    },
+    {
+      "code": "mla",
+      "name": "Mulberry Street Adult"
+    },
+    {
+      "code": "mm",
+      "name": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
+      "code": "mma",
+      "name": "Mid-Manhattan Adult"
+    },
+    {
+      "code": "mna",
+      "name": "Mariner's Harbor Adult "
+    },
+    {
+      "code": "moa",
+      "name": "Mosholu Adult"
+    },
+    {
+      "code": "mpa",
+      "name": "Morris Park Adult"
+    },
+    {
+      "code": "mra",
+      "name": "Morrisania Adult"
+    },
+    {
+      "code": "mua",
+      "name": "Muhlenberg Adult"
+    },
+    {
+      "code": "mya",
+      "name": "Performing Arts - Adult"
+    },
+    {
+      "code": "nba",
+      "name": "West New Brighton Adult"
+    },
+    {
+      "code": "nda",
+      "name": "New Dorp Adult"
+    },
+    {
+      "code": "ota",
+      "name": "Ottendorfer Adult"
+    },
+    {
+      "code": "pka",
+      "name": "Parkchester Adult"
+    },
+    {
+      "code": "pma",
+      "name": "Pelham Bay Adult"
+    },
+    {
+      "code": "pra",
+      "name": "Port Richmond Adult"
+    },
+    {
+      "code": "rda",
+      "name": "Riverdale Adult"
+    },
+    {
+      "code": "ria",
+      "name": "Roosevelt Island Adult"
+    },
+    {
+      "code": "rsa",
+      "name": "Riverside Adult"
+    },
+    {
+      "code": "rta",
+      "name": "Richmondtown Adult"
+    },
+    {
+      "code": "saa",
+      "name": "St. Agnes Adult"
+    },
+    {
+      "code": "sba",
+      "name": "South Beach Adult"
+    },
+    {
+      "code": "sda",
+      "name": "Sedgwick Adult"
+    },
+    {
+      "code": "sea",
+      "name": "Seward Park Adult"
+    },
+    {
+      "code": "sga",
+      "name": "St. George Adult"
+    },
+    {
+      "code": "sta",
+      "name": "Stapleton Adult"
+    },
+    {
+      "code": "sva",
+      "name": "Soundview Adult"
+    },
+    {
+      "code": "tga",
+      "name": "Throg's Neck Adult"
+    },
+    {
+      "code": "tha",
+      "name": "Todt Hill-Westerleigh Adult"
+    },
+    {
+      "code": "thj",
+      "name": "Todt Hill-Westerleigh Children"
+    },
+    {
+      "code": "tma",
+      "name": "Tremont Adult"
+    },
+    {
+      "code": "tsa",
+      "name": "Tompkins Square Adult"
+    },
+    {
+      "code": "tva",
+      "name": "Tottenville Adult"
+    },
+    {
+      "code": "vca",
+      "name": "Van Cortlandt Adult"
+    },
+    {
+      "code": "vna",
+      "name": "Pelham Parkway-Van Nest Adult"
+    },
+    {
+      "code": "wba",
+      "name": "Webster Adult"
+    },
+    {
+      "code": "wfa",
+      "name": "West Farms Adult"
+    },
+    {
+      "code": "wha",
+      "name": "Washington Heights Adult"
+    },
+    {
+      "code": "wka",
+      "name": "Wakefield Adult"
+    },
+    {
+      "code": "wla",
+      "name": "Woodlawn Heights Adult"
+    },
+    {
+      "code": "woa",
+      "name": "Woodstock Adult"
+    },
+    {
+      "code": "wta",
+      "name": "Westchester Square Adult"
+    },
+    {
+      "code": "wtj",
+      "name": "Westchester Square Children"
+    },
+    {
+      "code": "yva",
+      "name": "Yorkville Adult"
+    },
+    {
+      "code": "scd",
+      "name": "Schomburg Center - Manuscripts & Archives"
+    },
+    {
+      "code": "scf",
+      "name": "Schomburg Center - Research & Reference"
+    },
+    {
+      "code": "mal",
+      "name": "SASB - Service Desk Rm 315"
+    }
+  ],
+  "suppressed": true,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "Laptops.",
+  "author": "",
+  "materialType": {
+    "code": "-",
+    "value": "MISC"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 9999,
+  "catalogDate": "2009-01-27",
+  "country": {
+    "code": "xx ",
+    "name": "Unknown or undetermined"
+  },
+  "normTitle": "laptops",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "multi",
+      "display": null
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1897",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2009-01-27",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "-",
+      "display": "MISC"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "q",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "17990921",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-02-14T02:49:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-04-09T20:20:11Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "262",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "xx ",
+      "display": "Unknown or undetermined"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-04-06T01:31:58Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "c",
+      "marcTag": "091",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "LAPTOP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Wireless laptop computers are available for in-library use by the public; they may also be used to support public and staff training workload responsibilities and other scheduled events. Governed by EnvisionWare, laptops may be checked-out for forty-five (45) minute sessions by eligible users of all ages."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Laptops."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Circulating laptops"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Wireless laptops"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Laptops in the branches"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Laptop circulation"
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "995",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "1622119"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20090408123542.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "007",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "zu",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "090312|99999999xx            |   zzeng||nrm a ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "856",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "Reserve a Laptop"
+        },
+        {
+          "tag": "u",
+          "content": "http://legacy.www.nypl.org/pcres/reserve.pl"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "jlb"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000nrm  2200133 a 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/fixtures/item-cee-lo.json
+++ b/spec/fixtures/item-cee-lo.json
@@ -1,0 +1,252 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "18672258"
+  ],
+  "id": "25855062",
+  "nyplType": "item",
+  "updatedDate": "2019-04-10T20:52:48-04:00",
+  "createdDate": "2010-11-22T15:39:00-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "rsa0v",
+    "name": "Riverside Non-Print Media"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": "2019-05-01T08:00:00+00:00"
+  },
+  "barcode": "33333289418770",
+  "callNumber": null,
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": "true",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "233",
+      "display": "YA CD"
+    },
+    "62": {
+      "label": "Price",
+      "value": "1899.000000",
+      "display": null
+    },
+    "63": {
+      "label": "Checkout Date",
+      "value": "2019-03-21T15:42:25Z",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "800",
+      "display": null
+    },
+    "65": {
+      "label": "Due Date",
+      "value": "2019-05-01T08:00:00Z",
+      "display": null
+    },
+    "66": {
+      "label": "Patron No.",
+      "value": "4776885",
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": "2017-08-07T16:25:19Z",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "391",
+      "display": null
+    },
+    "71": {
+      "label": "No. of Renewals",
+      "value": "1",
+      "display": null
+    },
+    "72": {
+      "label": "No. of Overdues",
+      "value": "0",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "33",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "11",
+      "display": null
+    },
+    "78": {
+      "label": "Last Checkout Date",
+      "value": "2017-07-27T22:34:25Z",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rsa0v",
+      "display": "Riverside Non-Print Media"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "25855062",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2010-11-22T15:39:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-04-10T20:52:48Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "186",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "87": {
+      "label": "Loanrule",
+      "value": "4",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-04-08T00:59:21Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "-",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "1",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "1",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "0",
+      "display": "Undefined"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33333289418770",
+      "subfields": null
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "Midwest",
+      "subfields": null
+    },
+    {
+      "fieldTag": "x",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "o13313551",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/fixtures/item-laptop.json
+++ b/spec/fixtures/item-laptop.json
@@ -1,0 +1,222 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "17990921"
+  ],
+  "id": "34132673",
+  "nyplType": "item",
+  "updatedDate": "2019-04-10T17:36:22-04:00",
+  "createdDate": "2016-06-06T19:20:00-04:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "sga0v",
+    "name": "St. George Non-Print Media"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "33333406215299",
+  "callNumber": null,
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": "false",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "p",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "128",
+      "display": "Wireless laptop"
+    },
+    "62": {
+      "label": "Price",
+      "value": "200000.000000",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "79",
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": "2019-04-10T17:36:22Z",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "79",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "183",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "0",
+      "display": null
+    },
+    "78": {
+      "label": "Last Checkout Date",
+      "value": "2019-04-10T16:24:39Z",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "sga0v",
+      "display": "St. George Non-Print Media"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "34132673",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2016-06-06T19:20:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-04-10T17:36:22Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "372",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-04-10T16:24:54Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "1",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "38",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "140",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "0",
+      "display": "Undefined"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33333406215299",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "S-SG-LAP-TEN-40 ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "x",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "Serial #        5CG5222DZZ;       A063309",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/s3_writer_spec.rb
+++ b/spec/s3_writer_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe S3Writer do
+  describe '#feed_xml' do
+    describe 'cd item' do
+      before(:each) do
+        mock_api_client = instance_double(PlatformApiClient)
+        allow(PlatformApiClient).to receive(:new).and_return(mock_api_client)
+        allow(mock_api_client).to receive(:get).and_return({ "data" => fixture('bib-cee-lo.json') })
+
+        mock_s3_client = instance_double(S3Client)
+        allow(S3Client).to receive(:new).and_return(mock_s3_client)
+        allow(mock_s3_client).to receive(:write).and_return({ "stuff" => true })
+
+        load File.join('application.rb')
+      end
+
+      it 'generates feed' do
+        feed_xml = S3Writer.new.feed_xml([
+          Checkout.from_item_record(fixture('item-cee-lo.json'))
+        ])
+
+        expect(feed_xml).to be_a(String)
+
+        feed = Nokogiri::XML(feed_xml)
+        expect(feed).to be_a(Nokogiri::XML::Document)
+
+        entries = feed.xpath('//xmlns:feed/xmlns:entry')
+        expect(entries.size).to eq(1)
+
+        expect(entries[0].xpath('xmlns:title').text).to eq('"The lady killer [sound recording]" by Cee-Lo (Musician)')
+        expect(entries[0].xpath('dcterms:title').text).to eq('The lady killer [sound recording]')
+        expect(entries[0].xpath('dc:contributor').text).to eq('Cee-Lo (Musician)')
+      end
+    end
+
+    describe 'laptop item' do
+      before(:each) do
+        mock_api_client = instance_double(PlatformApiClient)
+        allow(PlatformApiClient).to receive(:new).and_return(mock_api_client)
+        allow(mock_api_client).to receive(:get).and_return({ "data" => fixture('bib-laptop.json') })
+
+        mock_s3_client = instance_double(S3Client)
+        allow(S3Client).to receive(:new).and_return(mock_s3_client)
+        allow(mock_s3_client).to receive(:write).and_return({ "stuff" => true })
+
+        load File.join('application.rb')
+      end
+
+      it 'generates feed' do
+        feed_xml = S3Writer.new.feed_xml([
+          Checkout.from_item_record(fixture('item-laptop.json'))
+        ])
+
+        expect(feed_xml).to be_a(String)
+
+        feed = Nokogiri::XML(feed_xml)
+        expect(feed).to be_a(Nokogiri::XML::Document)
+
+        entries = feed.xpath('//xmlns:feed/xmlns:entry')
+        expect(entries.size).to eq(1)
+        expect(entries[0].xpath('xmlns:title').text).to eq('"Laptops."')
+        expect(entries[0].xpath('dcterms:title').text).to eq('Laptops.')
+        expect(entries[0].xpath('dc:contributor').size).to eq(0)
+      end
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require_relative File.join('..', 'lib', 's3_writer')
+require_relative File.join('..', 'lib', 'platform_api_client')
+require_relative File.join('..', 'lib', 'checkout')
+
+def fixture(which)
+  return JSON.parse(File.read(File.join('spec', 'fixtures', which)))
+end


### PR DESCRIPTION
Adds:
 - a few foundational rspec tests
 - better checking of Checkout properties (i.e. fixes https://jira.nypl.org/browse/SCC-1336)
 - removes Checkout.catalog_url because we're calling it 'link'
 - When parsing item MiJ document, checks for missing 'status' struct before accessing