### PR TITLE
Document bundle installing in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ This app listens on the Item kinesis stream to identify Item updates that *look 
 ## Setup
 ### Installation
 
+1. Open a shell into the docker container:
+`docker run -it --rm -v "$PWD":/var/task lambci/lambda:build-ruby2.5 bash`
+
+2. Bundle install:
+
 ```
 bundle install; bundle install --deployment
 ```
+3. `exit`
 
 ### Setup
 


### PR DESCRIPTION
It seems like running bundle install in the docker container fixed some issues I was having with Nokogiri, but I'm not sure if this is really correct. What do you think?

This PR updates the README under the assumption this is right.