### PR TITLE
Dedup

### DIFF
--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -71,7 +71,7 @@ class ItemStreamHandler
         # Presence of 'duedate' indicates it's checked-out
         if decoded && decoded['status'] && ! decoded['status']['duedate'].nil?
           checkout = Checkout.from_item_record decoded
-          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now < ENV["CHECKOUT_ID_EXPIRE_TIME"].to_i
+          unless RECENT_IDS[checkout.id] && Time.now - RECENT_IDS[checkout.id]< ENV["CHECKOUT_ID_EXPIRE_TIME"].to_i
             add_checkout checkout
             checkout_count += 1
             update_count checkout

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -50,7 +50,7 @@ class ItemStreamHandler
 
   def remove_old_ids(id_hash)
     id_hash.each do |(id, time)|
-      id_hash.delete(id) if Time.now - time > ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
+      id_hash.delete(id) if Time.now - time > ENV["CHECKOUT_ID_EXPIRE_TIME"].to_i
     end
   end
 
@@ -71,7 +71,7 @@ class ItemStreamHandler
         # Presence of 'duedate' indicates it's checked-out
         if decoded && decoded['status'] && ! decoded['status']['duedate'].nil?
           checkout = Checkout.from_item_record decoded
-          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now < ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
+          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now < ENV["CHECKOUT_ID_EXPIRE_TIME"].to_i
             add_checkout checkout
             checkout_count += 1
             update_count checkout

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -65,7 +65,7 @@ class ItemStreamHandler
         # Presence of 'duedate' indicates it's checked-out
         if decoded && decoded['status'] && ! decoded['status']['duedate'].nil?
           checkout = Checkout.from_item_record decoded
-          unless RECENT_IDS[checkout.id] - Time.now > ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
+          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now > ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
             add_checkout checkout
             checkout_count += 1
             update_count checkout

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -65,7 +65,7 @@ class ItemStreamHandler
         # Presence of 'duedate' indicates it's checked-out
         if decoded && decoded['status'] && ! decoded['status']['duedate'].nil?
           checkout = Checkout.from_item_record decoded
-          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now > ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
+          unless RECENT_IDS[checkout.id] && RECENT_IDS[checkout.id] - Time.now < ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
             add_checkout checkout
             checkout_count += 1
             update_count checkout

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -48,6 +48,12 @@ class ItemStreamHandler
     end
   end
 
+  def remove_old_ids(id_hash)
+    id_hash.each do |(id, time)|
+      id_hash.delete(id) if Time.now - time > ENV[CHECKOUT_ID_EXPIRE_TIME]
+    end
+  end
+
 
   # Handle storage of proxied requests
   def handle (event)
@@ -70,6 +76,7 @@ class ItemStreamHandler
             checkout_count += 1
             update_count checkout
             RECENT_IDS[checkout.id] = Time.now
+            remove_old_ids RECENT_IDS
           end
         end
       end

--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -50,7 +50,7 @@ class ItemStreamHandler
 
   def remove_old_ids(id_hash)
     id_hash.each do |(id, time)|
-      id_hash.delete(id) if Time.now - time > ENV[CHECKOUT_ID_EXPIRE_TIME]
+      id_hash.delete(id) if Time.now - time > ENV[CHECKOUT_ID_EXPIRE_TIME].to_i
     end
   end
 

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -20,3 +20,4 @@ Resources:
           S3_FEED_KEY: 'feed.xml'
           LOG_LEVEL: debug
           TZ: 'America/New_York'
+          CHECKOUT_ID_EXPIRE_TIME: 60*60

--- a/spec/item_stream_handler_spec.rb
+++ b/spec/item_stream_handler_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe ItemStreamHandler do
+  describe '#handle' do
+    describe 'deduping based on ids' do
+      ItemTypeTally = {
+        time: Time.now,
+        tallies: Hash.new {|h,k| h[k] = 0 }
+      }
+      irrelevant = []
+      Application = irrelevant
+      item_stream_handler = ItemStreamHandler.new
+      mock_event = {
+        "Records" => [
+          {
+            "eventSource" => "aws:kinesis",
+            "kinesis" => {
+              "data" => "FAKE_DATA"
+            }
+          }
+        ]
+      }
+      decoded_data = {
+        "status" => {
+          "duedate" => "12/31/3000"
+        }
+      }
+      mock_decoder = {}
+      mock_checkout = {}
+
+      before(:each) do
+        ENV['CHECKOUT_ID_EXPIRE_TIME'] = '1000000'
+        allow(mock_decoder).to receive(:decode).and_return(decoded_data)
+        allow(AvroDecoder).to receive(:by_name).and_return(mock_decoder)
+        allow(mock_checkout).to receive(:id).and_return(1)
+        allow(Checkout).to receive(:from_item_record).and_return(mock_checkout)
+        allow(item_stream_handler).to receive(:add_checkout).and_return(nil)
+        allow(item_stream_handler).to receive(:update_count).and_return(nil)
+        allow(irrelevant).to receive_messages(logger: irrelevant, info: irrelevant, s3_writer: irrelevant, write: irrelevant)
+      end
+
+      it 'should process a checkout with a new id' do
+        item_stream_handler.handle(mock_event)
+        expect(item_stream_handler).to have_received(:add_checkout).once
+      end
+
+      it 'should not process a checkout with a recent id' do
+        item_stream_handler.handle(mock_event)
+        expect(item_stream_handler).not_to have_received(:add_checkout)
+      end
+
+      it 'should process a checkout with an old id' do
+        ENV['CHECKOUT_ID_EXPIRE_TIME'] = nil
+        item_stream_handler.handle(mock_event)
+        expect(item_stream_handler).to have_received(:add_checkout).once
+      end
+    end
+  end
+end

--- a/spec/item_stream_handler_spec.rb
+++ b/spec/item_stream_handler_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe ItemStreamHandler do
   describe '#handle' do
     describe 'deduping based on ids' do
+      Application ||= []
       ItemTypeTally = {
         time: Time.now,
         tallies: Hash.new {|h,k| h[k] = 0 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require_relative File.join('..', 'lib', 's3_writer')
 require_relative File.join('..', 'lib', 'platform_api_client')
 require_relative File.join('..', 'lib', 'checkout')
+require_relative File.join('..', 'lib', 'item_stream_handler')
 
 def fixture(which)
   return JSON.parse(File.read(File.join('spec', 'fixtures', which)))


### PR DESCRIPTION
This addresses SCC-1406, Backend: De-dupe based on itemid. I've set it up to ignore checkouts with ids that have been processed recently, based on a configurable time that I have set to 1 hr. There's not a lot of detail in the ticket, so let me know if you have a different idea as to how we should dedup