### PR TITLE
Add check for varfields and subfields being arrays in marc methods

### DIFF
--- a/lib/marc_util.rb
+++ b/lib/marc_util.rb
@@ -1,12 +1,14 @@
 class MarcUtil
   def self.var_block(record, marc)
+    return nil unless record && record['varFields'] && record['varFields'].is_a?(Array)
     record['varFields']
       .select { |field| field['marcTag'] == marc }
       .first
   end
 
   def self.subfield_block(var_block, subfield)
-    var_block && var_block['subfields']
+    return nil unless var_block && var_block['subfields'] && var_block['subfields'].is_a?(Array)
+    var_block['subfields']
       .select { |subfield_b| subfield_b['tag'] == subfield }
       .first
   end


### PR DESCRIPTION
We keep getting a repeated error in the logs of the form:
```
"errorMessage": "private method `select' called for nil:NilClass",
"errorType": "Function<NoMethodError>",
"stackTrace": [
"/var/task/lib/checkout.rb:16:in `marc_value'",
"/var/task/lib/checkout.rb:47:in `from_item_record'",
"/var/task/lib/item_stream_handler.rb:50:in `block in handle'",
"/var/task/lib/item_stream_handler.rb:43:in `each'",
"/var/task/lib/item_stream_handler.rb:43:in `handle'",
"/var/task/application.rb:17:in `handle_event'"
```

I hope this fixed the errors but we probably have to do more investigation. As of now the item-checkout-feed-updater is not working