### PR TITLE
Fix uniform method to use corrected time of latest record as a base

### DIFF
--- a/lib/checkout_builder_util.rb
+++ b/lib/checkout_builder_util.rb
@@ -23,7 +23,7 @@ class CheckoutBuilderUtil
     checkout.location_type = self.location_type checkout.item_type
     checkout.id = item['id']
     checkout.barcode = item['barcode']
-    checkout.created = item['updatedDate']
+    checkout.created = item['updatedDate'][0...-6] + "-00:00"
   end
 
   def self.assign_isbn(bib, checkout)

--- a/lib/randomization_util.rb
+++ b/lib/randomization_util.rb
@@ -12,6 +12,13 @@ class RandomizationHelperUtil
     checkouts.select { |checkout| !checkout.randomized_date }
   end
 
+  def self.last_time(checkouts)
+    checkouts
+      .map { |checkout| Time.parse(checkout.created) }
+      .sort
+      .last
+  end
+
 end
 
 class PostProcessingRandomizationUtil
@@ -29,11 +36,12 @@ class PostProcessingRandomizationUtil
 
   def self.uniform(opts)
     # Generate random creation times over covered timespan:
+    last_time = RandomizationHelperUtil.last_time opts[:new_checkouts]
     opts[:new_checkouts]
       .map { |ind| rand RandomizationHelperUtil.delta_seconds(opts[:new_checkouts]) }
       .sort
       .reverse
-      .map { |s| Time.at(Time.now - s).iso8601 }
+      .map { |s| Time.at(last_time - s).iso8601 }
   end
 
   def self.add_randomized_dates!(checkouts)

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -16,7 +16,7 @@ describe Checkout do
 
         expect(checkout).to be_a(Checkout)
         expect(checkout.id).to eq('34132673')
-        expect(checkout.created).to eq('2019-04-10T17:36:22-04:00')
+        expect(checkout.created).to eq('2019-04-10T17:36:22-00:00')
         expect(checkout.isbn).to be_nil
         expect(checkout.barcode).to eq('33333406215299')
         expect(checkout.title).to eq('Laptops.')
@@ -39,7 +39,7 @@ describe Checkout do
 
         expect(checkout).to be_a(Checkout)
         expect(checkout.id).to eq('25855062')
-        expect(checkout.created).to eq('2019-04-10T20:52:48-04:00')
+        expect(checkout.created).to eq('2019-04-10T20:52:48-00:00')
         expect(checkout.isbn).to be_nil
         expect(checkout.barcode).to eq('33333289418770')
         expect(checkout.title).to eq('The lady killer [sound recording]')
@@ -49,4 +49,3 @@ describe Checkout do
     end
   end
 end
-


### PR DESCRIPTION
This branch: 1) Corrects the created time of checkouts to use UTC instead of local time 2) Changes the uniform method to count back from the time of the last record, rather than the current time 3) Changes tests to match the new expectations about timestamps