### PR TITLE
Fix process and random_shuffle to be class methods

### DIFF
--- a/lib/item_stream_handler.rb
+++ b/lib/item_stream_handler.rb
@@ -64,7 +64,6 @@ class ItemStreamHandler
     records = event["Records"]
       .select { |record| record["eventSource"] == "aws:kinesis" }
 
-
     records = PreProcessingRandomizationUtil.process(records)
 
     decoded_records = records

--- a/lib/randomization_util.rb
+++ b/lib/randomization_util.rb
@@ -90,7 +90,7 @@ class PreProcessingRandomizationUtil
     args[0]
   end
 
-  def random_shuffle(array)
+  def self.random_shuffle(array)
     array
       .map { |record| [rand, record] }
       .sort { |(float, record)| float}
@@ -101,7 +101,7 @@ class PreProcessingRandomizationUtil
   # The possible values for 'RANDOMIZATION_METHOD' should be exactly names
   # of those methods in
   # PreProcessingRandomizationUtil and PostProcessingRandomizationUtil
-  def process(array)
+  def self.process(array)
     self.send(ENV['RANDOMIZATION_METHOD'], records)
   end
 end

--- a/lib/randomization_util.rb
+++ b/lib/randomization_util.rb
@@ -102,6 +102,6 @@ class PreProcessingRandomizationUtil
   # of those methods in
   # PreProcessingRandomizationUtil and PostProcessingRandomizationUtil
   def self.process(array)
-    self.send(ENV['RANDOMIZATION_METHOD'], records)
+    self.send(ENV['RANDOMIZATION_METHOD'], array)
   end
 end


### PR DESCRIPTION
Fixes a problem that surfaced while writing tests. `random_shuffle` and `process` are supposed to be class methods, but aren't. 